### PR TITLE
Fixed special characters to be valid UTF-8 characters

### DIFF
--- a/src/main/java/gov/pnnl/prosser/api/AbstractSimulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/AbstractSimulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/Experiment.java
+++ b/src/main/java/gov/pnnl/prosser/api/Experiment.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import java.nio.file.Path;

--- a/src/main/java/gov/pnnl/prosser/api/ExperimentMain.java
+++ b/src/main/java/gov/pnnl/prosser/api/ExperimentMain.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import java.io.BufferedOutputStream;

--- a/src/main/java/gov/pnnl/prosser/api/FncsSimulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/FncsSimulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/FncsSimulatorWriter.java
+++ b/src/main/java/gov/pnnl/prosser/api/FncsSimulatorWriter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import gov.pnnl.prosser.api.fncs.Fncs;

--- a/src/main/java/gov/pnnl/prosser/api/GldSimulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/GldSimulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import gov.pnnl.prosser.api.gld.AbstractGldObject;

--- a/src/main/java/gov/pnnl/prosser/api/GldSimulatorWriter.java
+++ b/src/main/java/gov/pnnl/prosser/api/GldSimulatorWriter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import gov.pnnl.prosser.api.gld.AbstractGldObject;

--- a/src/main/java/gov/pnnl/prosser/api/HeatTemplateWriter.java
+++ b/src/main/java/gov/pnnl/prosser/api/HeatTemplateWriter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import java.io.BufferedWriter;

--- a/src/main/java/gov/pnnl/prosser/api/NetworkCapable.java
+++ b/src/main/java/gov/pnnl/prosser/api/NetworkCapable.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/Ns3ExperimentMain.java
+++ b/src/main/java/gov/pnnl/prosser/api/Ns3ExperimentMain.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import java.net.URL;

--- a/src/main/java/gov/pnnl/prosser/api/Ns3Simulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/Ns3Simulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import gov.pnnl.prosser.api.gld.obj.AuctionObject;

--- a/src/main/java/gov/pnnl/prosser/api/Ns3SimulatorWriter.java
+++ b/src/main/java/gov/pnnl/prosser/api/Ns3SimulatorWriter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ThirdPartySimulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/ThirdPartySimulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import java.nio.file.Path;

--- a/src/main/java/gov/pnnl/prosser/api/ThirdPartySimulatorWriter.java
+++ b/src/main/java/gov/pnnl/prosser/api/ThirdPartySimulatorWriter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api;
 
 import java.io.BufferedWriter;

--- a/src/main/java/gov/pnnl/prosser/api/c/obj/Pointer.java
+++ b/src/main/java/gov/pnnl/prosser/api/c/obj/Pointer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.c.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/c/obj/StringMap.java
+++ b/src/main/java/gov/pnnl/prosser/api/c/obj/StringMap.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.c.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/c/obj/Vector.java
+++ b/src/main/java/gov/pnnl/prosser/api/c/obj/Vector.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.c.obj;
 
 import gov.pnnl.prosser.api.NetworkCapable;

--- a/src/main/java/gov/pnnl/prosser/api/c/obj/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/c/obj/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * C++ Classes

--- a/src/main/java/gov/pnnl/prosser/api/fncs/Fncs.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/Fncs.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/gov/pnnl/prosser/api/fncs/FncsIface.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/FncsIface.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/fncs/FncsSimType.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/FncsSimType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/gov/pnnl/prosser/api/fncs/FncsSyncAlgo.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/FncsSyncAlgo.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/fncs/FncsTimeMetric.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/FncsTimeMetric.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/fncs/Subscription.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/Subscription.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 import gov.pnnl.prosser.api.AbstractSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/fncs/SyncParams.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/SyncParams.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.fncs;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/gov/pnnl/prosser/api/fncs/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/fncs/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * FNCS Simulator Model

--- a/src/main/java/gov/pnnl/prosser/api/gld/AbstractGldObject.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/AbstractGldObject.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/ConvertLoadToHouses.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/ConvertLoadToHouses.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import java.util.EnumSet;

--- a/src/main/java/gov/pnnl/prosser/api/gld/GldSerializable.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/GldSerializable.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import gov.pnnl.prosser.api.sql.SqlFile;

--- a/src/main/java/gov/pnnl/prosser/api/gld/GldSimulatorUtils.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/GldSimulatorUtils.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/GlmParser.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/GlmParser.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import java.io.BufferedReader;

--- a/src/main/java/gov/pnnl/prosser/api/gld/HouseRegionalization.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/HouseRegionalization.java
@@ -1,37 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*
-*
- * Provides generalation of house parameter
- * diversity for various regions of the country
- */
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 

--- a/src/main/java/gov/pnnl/prosser/api/gld/HouseType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/HouseType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/Ieee123NodeTestFeeder.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/Ieee123NodeTestFeeder.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import java.awt.Point;

--- a/src/main/java/gov/pnnl/prosser/api/gld/Ieee8500NodeTestFeeder.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/Ieee8500NodeTestFeeder.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld;
 
 import java.io.BufferedReader;

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/AuxiliaryStrategy.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/AuxiliaryStrategy.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/AuxiliarySystemType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/AuxiliarySystemType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/BidMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/BidMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/BusType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/BusType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/CapacitorControl.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/CapacitorControl.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/CoefficientOfPerformanceData.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/CoefficientOfPerformanceData.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/ConnectionType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/ConnectionType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/ControlLevel.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/ControlLevel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/ControlMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/ControlMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/CoolingSystemType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/CoolingSystemType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/CurveOutput.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/CurveOutput.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/DistributionType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/DistributionType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/FanType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/FanType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/FourQuadrantControlMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/FourQuadrantControlMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/GeneratorMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/GeneratorMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/GeneratorStatus.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/GeneratorStatus.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/HeatingSystemType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/HeatingSystemType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/ImplicitEnduses.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/ImplicitEnduses.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/InstallationType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/InstallationType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/InverterManufacturer.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/InverterManufacturer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/InverterType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/InverterType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/MarketSetUp.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/MarketSetUp.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/MotorEfficiency.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/MotorEfficiency.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/MotorModel.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/MotorModel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/Orientation.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/Orientation.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/PanelType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/PanelType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/PhaseCode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/PhaseCode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 import java.util.EnumSet;

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/Region.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/Region.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/RegulatorControl.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/RegulatorControl.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/RegulatorType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/RegulatorType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/RepairDistributionType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/RepairDistributionType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/SolarPowerModel.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/SolarPowerModel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/SolarTiltModel.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/SolarTiltModel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/SolverMethod.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/SolverMethod.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/SpecialMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/SpecialMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/SwitchStatus.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/SwitchStatus.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/TurbineModel.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/TurbineModel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/UseOverride.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/UseOverride.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/WaterheaterLocation.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/WaterheaterLocation.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/WindTurbineGeneratorMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/WindTurbineGeneratorMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/WindTurbineGeneratorType.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/WindTurbineGeneratorType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/enums/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/enums/package-info.java
@@ -1,31 +1,31 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.enums;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/Conductor.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/Conductor.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/GldClock.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/GldClock.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import gov.pnnl.prosser.api.gld.GldSerializable;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/LineConfiguration.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/LineConfiguration.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/LineSpacing.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/LineSpacing.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/OverheadLineConductor.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/OverheadLineConductor.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/PowerflowLibrary.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/PowerflowLibrary.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/RegulatorConfiguration.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/RegulatorConfiguration.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/StandardLineConfiguration.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/StandardLineConfiguration.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/TransformerConfiguration.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/TransformerConfiguration.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/TriplexLineConductor.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/TriplexLineConductor.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/TriplexLineConfiguration.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/TriplexLineConfiguration.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/UndergroundLineConductor.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/UndergroundLineConductor.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.lib;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/lib/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/lib/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * GridLab-D Powerflow library

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/ClimateModule.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/ClimateModule.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/Comm.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/Comm.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/Connection.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/Connection.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/Market.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/Market.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/Module.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/Module.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 import gov.pnnl.prosser.api.gld.GldSerializable;

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/PowerflowModule.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/PowerflowModule.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 import gov.pnnl.prosser.api.gld.enums.SolverMethod;

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/Residential.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/Residential.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 import gov.pnnl.prosser.api.gld.enums.ImplicitEnduses;

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/Tape.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/Tape.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/module/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/module/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * GridLab-D Modules

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/AbstractGldClass.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/AbstractGldClass.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.gld.GldSerializable;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/AuctionClass.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/AuctionClass.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/AuctionObject.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/AuctionObject.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Capacitor.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Capacitor.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.EnumSet;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/ClimateObject.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/ClimateObject.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Controller.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Controller.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/CsvReader.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/CsvReader.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/DieselDistributedGeneration.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/DieselDistributedGeneration.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.lang.reflect.Field;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/FncsMsg.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/FncsMsg.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Fuse.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Fuse.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/House.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/House.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Inverter.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Inverter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import org.apache.commons.math3.complex.Complex;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Line.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Line.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/LinkObject.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/LinkObject.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Load.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Load.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Meter.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Meter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Node.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Node.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/OverheadLine.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/OverheadLine.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/PassiveController.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/PassiveController.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/PlayerClass.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/PlayerClass.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/PlayerObject.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/PlayerObject.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/PowerflowObject.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/PowerflowObject.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Recorder.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Recorder.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Regulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Regulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/ResidentialEnduse.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/ResidentialEnduse.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Solar.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Solar.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import org.apache.commons.math3.complex.Complex;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Substation.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Substation.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Switch.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Switch.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/Transformer.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/Transformer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/TriplexLine.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/TriplexLine.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/TriplexMeter.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/TriplexMeter.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/TriplexNode.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/TriplexNode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/UndergroundLine.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/UndergroundLine.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/WaterHeater.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/WaterHeater.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/WindTurbine.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/WindTurbine.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.lang.reflect.Field;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/ZIPLoad.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/ZIPLoad.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.gld.obj;
 
 import java.util.Objects;

--- a/src/main/java/gov/pnnl/prosser/api/gld/obj/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/obj/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * GridLab-D Powerflow Object Model

--- a/src/main/java/gov/pnnl/prosser/api/gld/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/gld/package-info.java
@@ -1,33 +1,35 @@
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
+
 /**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*
- * GridLab-D Base Classes http://gridlab-d.sourceforge.net/doxygen/3.0/
+ *  GridLab-D Base Classes http://gridlab-d.sourceforge.net/doxygen/3.0/
  */
 package gov.pnnl.prosser.api.gld;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/AbstractNs3Object.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/AbstractNs3Object.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3;
 
 import gov.pnnl.prosser.api.Ns3Simulator;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/AbstractNs3SimulatorV2.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/AbstractNs3SimulatorV2.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3;
 
 import java.io.IOException;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/Ns3Includes.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/Ns3Includes.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/Ns3SimulatorV2Arion.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/Ns3SimulatorV2Arion.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3;
 
 import java.io.BufferedWriter;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/Ns3SimulatorV2DelayDrop.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/Ns3SimulatorV2DelayDrop.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3;
 
 import java.io.BufferedWriter;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/Ns3SimulatorV2FirstN.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/Ns3SimulatorV2FirstN.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3;
 
 import java.io.BufferedWriter;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/FileHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/FileHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/FlowMonitorHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/FlowMonitorHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/GnuplotHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/GnuplotHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * Classes providing data collection (collecting, processing, outputting) capabilities.

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/DoubleProbe.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/DoubleProbe.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection.probes;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/Ipv4PacketProbe.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/Ipv4PacketProbe.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection.probes;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/Ipv6PacketProbe.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/Ipv6PacketProbe.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection.probes;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/PacketProbe.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/PacketProbe.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection.probes;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/Probe.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/datacollection/probes/Probe.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.datacollection.probes;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/CsmaSources.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/CsmaSources.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/FileFormat.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/FileFormat.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/Ipv4L3Protocol.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/Ipv4L3Protocol.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/Ipv4PacketProbe.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/Ipv4PacketProbe.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/Ipv6L3Protocol.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/Ipv6L3Protocol.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/KeyLocation.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/KeyLocation.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/MacSources.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/MacSources.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/MobilityModel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/MobilityModel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/NetworkType.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/NetworkType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/PhySources.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/PhySources.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/SnifferSources.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/SnifferSources.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/TraceSource.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/TraceSource.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.enums;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/enums/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/enums/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 Enums

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Applications.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Applications.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Bridge.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Bridge.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Core.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Core.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Csma.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Csma.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Cstdlib.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Cstdlib.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/FlowMonitorHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/FlowMonitorHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.module;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Fncs.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Fncs.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/FncsApplication.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/FncsApplication.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Internet.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Internet.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Iostream.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Iostream.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Lte.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Lte.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Map.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Map.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Mobility.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Mobility.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Module.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Module.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Namespace.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Namespace.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Network.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Network.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/NixVectorRouting.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/NixVectorRouting.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/PointToPoint.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/PointToPoint.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Stats.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Stats.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.module;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Stdexcept.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Stdexcept.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/Wifi.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/Wifi.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.module;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/module/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/module/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 Modules

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/Application.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/Application.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/ApplicationContainer.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/ApplicationContainer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/BridgeHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/BridgeHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import java.util.HashMap;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/Channel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/Channel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.gld.obj.AuctionObject;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/FNCSApplicationHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/FNCSApplicationHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.c.obj.StringMap;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/FncsSimulator.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/FncsSimulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/MobilityHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/MobilityHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/NetDevice.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/NetDevice.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/NetDeviceContainer.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/NetDeviceContainer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/NetworkHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/NetworkHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/Node.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/Node.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/NodeContainer.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/NodeContainer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import java.util.ArrayList;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/Ns3Network.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/Ns3Network.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import gov.pnnl.prosser.api.c.obj.Pointer;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/Router.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/Router.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj;
 
 import java.util.ArrayList;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/CsmaChannel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/CsmaChannel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.csma;
 
 import gov.pnnl.prosser.api.c.obj.Pointer;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/CsmaHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/CsmaHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.csma;
 
 import gov.pnnl.prosser.api.ns3.obj.NetDeviceContainer;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/CsmaNetDevice.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/CsmaNetDevice.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.csma;
 
 import gov.pnnl.prosser.api.ns3.obj.NetDevice;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/csma/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * Created by happ546 on 9/3/2015.

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/UdpEchoClientHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/UdpEchoClientHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.echo;
 
 import java.util.HashMap;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/UdpEchoHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/UdpEchoHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.echo;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/UdpEchoServerHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/UdpEchoServerHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.echo;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/echo/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 UDP echo application model

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/InternetStackHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/InternetStackHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 
 package gov.pnnl.prosser.api.ns3.obj.internet;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4Address.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4Address.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4AddressHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4AddressHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4GlobalRoutingHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4GlobalRoutingHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.internet;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4InterfaceAddress.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4InterfaceAddress.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4InterfaceContainer.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4InterfaceContainer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4ListRoutingHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4ListRoutingHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4Mask.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4Mask.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4NixVectorHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4NixVectorHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4StaticRouting.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4StaticRouting.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4StaticRoutingHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/Ipv4StaticRoutingHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.internet;
 
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/internet/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 Internet and IPv4 model

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/EpsBearer.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/EpsBearer.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.lte;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/LteHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/LteHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.lte;
 
 import gov.pnnl.prosser.api.c.obj.Pointer;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/PointToPointEpcHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/PointToPointEpcHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.lte;
 
 import gov.pnnl.prosser.api.c.obj.Pointer;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/Qci.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/Qci.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.lte;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/lte/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 LTE model

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/PointToPointChannel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/PointToPointChannel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.p2p;
 
 import gov.pnnl.prosser.api.ns3.enums.NetworkType;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/PointToPointHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/PointToPointHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.p2p;
 
 import gov.pnnl.prosser.api.ns3.obj.NetDeviceContainer;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/PointToPointNetDevice.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/PointToPointNetDevice.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.p2p;
 
 import gov.pnnl.prosser.api.ns3.obj.NetDevice;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/p2p/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 Point-to-Point model

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 Object Model

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/NqosWifiMacHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/NqosWifiMacHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/PcapDataLinkType.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/PcapDataLinkType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/Ssid.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/Ssid.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiChannel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiChannel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiMac.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiMac.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiMacType.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiMacType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiObjectBase.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiObjectBase.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiPhyMode.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiPhyMode.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiPhyStandard.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiPhyStandard.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiRemoteStationManager.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/WifiRemoteStationManager.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansErrorRateModel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansErrorRateModel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansWifiChannel.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansWifiChannel.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansWifiChannelHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansWifiChannelHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansWifiPhyHelper.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/YansWifiPhyHelper.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.ns3.obj.wifi;
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;

--- a/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/ns3/obj/wifi/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * NS-3 Wi-Fi model

--- a/src/main/java/gov/pnnl/prosser/api/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * Base Prosser API

--- a/src/main/java/gov/pnnl/prosser/api/sql/SqlColumnDef.java
+++ b/src/main/java/gov/pnnl/prosser/api/sql/SqlColumnDef.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  *

--- a/src/main/java/gov/pnnl/prosser/api/sql/SqlFile.java
+++ b/src/main/java/gov/pnnl/prosser/api/sql/SqlFile.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  *

--- a/src/main/java/gov/pnnl/prosser/api/sql/SqlTableDef.java
+++ b/src/main/java/gov/pnnl/prosser/api/sql/SqlTableDef.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  *

--- a/src/main/java/gov/pnnl/prosser/api/sql/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/sql/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 /**
  * SQL Model

--- a/src/main/java/gov/pnnl/prosser/api/thirdparty/enums/SimType.java
+++ b/src/main/java/gov/pnnl/prosser/api/thirdparty/enums/SimType.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 package gov.pnnl.prosser.api.thirdparty.enums;
 
 /**

--- a/src/main/java/gov/pnnl/prosser/api/thirdparty/enums/package-info.java
+++ b/src/main/java/gov/pnnl/prosser/api/thirdparty/enums/package-info.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 /**
  * @author fish334
  *

--- a/src/test/java/AdaptedAEPArionNs3Test.java
+++ b/src/test/java/AdaptedAEPArionNs3Test.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.gld.*;

--- a/src/test/java/AdaptedAEPFncsTest.java
+++ b/src/test/java/AdaptedAEPFncsTest.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.gld.*;

--- a/src/test/java/AdaptedAEPNs3Sim2Test.java
+++ b/src/test/java/AdaptedAEPNs3Sim2Test.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.gld.*;

--- a/src/test/java/BasicSimulator.java
+++ b/src/test/java/BasicSimulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.Experiment;
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/test/java/DataCollectionTest.java
+++ b/src/test/java/DataCollectionTest.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.Experiment;
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/test/java/ExperimentFncsTest.java
+++ b/src/test/java/ExperimentFncsTest.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.FncsSimulator;

--- a/src/test/java/IntegratedDemo.java
+++ b/src/test/java/IntegratedDemo.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.gld.*;

--- a/src/test/java/Ns3OnlyTest.java
+++ b/src/test/java/Ns3OnlyTest.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.gld.*;

--- a/src/test/java/TestNs3Simulator.java
+++ b/src/test/java/TestNs3Simulator.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.ns3.AbstractNs3Object;
 import gov.pnnl.prosser.api.ns3.module.Module;

--- a/src/test/java/TestSeanZExperiment.java
+++ b/src/test/java/TestSeanZExperiment.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.*;
 import gov.pnnl.prosser.api.gld.enums.*;

--- a/src/test/java/WifiFncsTest.java
+++ b/src/test/java/WifiFncsTest.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 import gov.pnnl.prosser.api.Experiment;
 import gov.pnnl.prosser.api.GldSimulator;

--- a/src/test/java/gov/pnnl/prosser/api/test/TestProsser.java
+++ b/src/test/java/gov/pnnl/prosser/api/test/TestProsser.java
@@ -1,33 +1,33 @@
-/**
-* Arion
-* Copyright © 2016, Battelle Memorial Institute
-* All rights reserved.
-* 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
-*    lawfully obtaining a copy of this software and associated documentation files (hereinafter “the Software”)
-*    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
-*    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-*    and may permit others to do so, subject to the following conditions:
-*    •  Redistributions of source code must retain the above copyright notice, this list of conditions and
-*       the following disclaimers.
-*    •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-*       the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    •  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
-*       form whatsoever without the express written consent of Battelle.
-* 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-*    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-*    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-*    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-*    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-*    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-*    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-*                                PACIFIC NORTHWEST NATIONAL LABORATORY
-*                                            operated by
-*                                              BATTELLE
-*                                              for the
-*                                  UNITED STATES DEPARTMENT OF ENERGY
-*                                   under Contract DE-AC05-76RL01830
-*/
+/*******************************************************************************
+ * Arion
+ * Copyright Â© 2016, Battelle Memorial Institute
+ * All rights reserved.
+ * 1. Battelle Memorial Institute (hereinafter Battelle) hereby grants permission to any person or entity
+ *    lawfully obtaining a copy of this software and associated documentation files (hereinafter "the Software")
+ *    to redistribute and use the Software in source and binary forms, with or without modification.  Such person
+ *    or entity may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ *    and may permit others to do so, subject to the following conditions:
+ *    â€¢  Redistributions of source code must retain the above copyright notice, this list of conditions and
+ *       the following disclaimers.
+ *    â€¢  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *    â€¢  Other than as used herein, neither the name Battelle Memorial Institute or Battelle may be used in any
+ *       form whatsoever without the express written consent of Battelle.
+ * 2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ *    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                                PACIFIC NORTHWEST NATIONAL LABORATORY
+ *                                            operated by
+ *                                              BATTELLE
+ *                                              for the
+ *                                  UNITED STATES DEPARTMENT OF ENERGY
+ *                                   under Contract DE-AC05-76RL01830
+ *******************************************************************************/
 
 package gov.pnnl.prosser.api.test;
 


### PR DESCRIPTION
The build wasn't working due to the non UTF-8 characters.  The bad characters were the ", the copyright symbol and the bullets.  I used the Eclipse Releng tools to replace the license and it did a bit more than just those few characters, hopefully that's ok.